### PR TITLE
Use keyed fields for OutputIdentifier struct

### DIFF
--- a/pkg/transport/transactions.go
+++ b/pkg/transport/transactions.go
@@ -36,7 +36,7 @@ func (txn *TransactionContainer) init(rawTx *btcjson.TxRawResult, utxos UTXOs, b
 
 			vinHasCoinbase = true
 		} else {
-			utxo := utxos[OutputIdentifier{rawVin.Txid, rawVin.Vout}]
+			utxo := utxos[OutputIdentifier{Hash: rawVin.Txid, Index: rawVin.Vout}]
 			outputIndex := rawVin.Vout
 
 			vin[idx] = Input{

--- a/pkg/transport/wire.go
+++ b/pkg/transport/wire.go
@@ -95,7 +95,7 @@ func (w Wire) buildUTXOs(vin []btcjson.Vin) (UTXOs, error) {
 				}
 			}
 		}(utxoRaw.ScriptPubKey.Addresses)
-		utxos[OutputIdentifier{inputRaw.Txid, inputRaw.Vout}] = utxo
+		utxos[OutputIdentifier{Hash: inputRaw.Txid, Index: inputRaw.Vout}] = utxo
 	}
 
 	return utxos, nil


### PR DESCRIPTION
Fixes the following warnings reported by `go vet`:

```
types.OutputIdentifier composite literal uses unkeyed fields
```
